### PR TITLE
Move noaa nautical basemap

### DIFF
--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -6,6 +6,16 @@
     </transition>   
     <l-map :style="mapStyleObj" :zoom="zoom" :center="center" ref="ettMap" alt="Data explorer map">
       <l-control-layers position="topleft"></l-control-layers>
+      <l-tile-layer
+        v-for="tile in basemaps[0]"
+        :key="tile.name"
+        :name="tile.name"
+        :visible="tile.visible"
+        :url="tile.url"
+        :attribution="tile.attribution"
+        :options="tile.options"
+        layer-type="base"
+      ></l-tile-layer>
       <l-wms-tile-layer
         v-for="tile in basemapsWms"
         :key="tile.name"
@@ -18,7 +28,7 @@
         layer-type="base"
       ></l-wms-tile-layer>
       <l-tile-layer
-        v-for="tile in basemaps"
+        v-for="tile in basemaps[1]"
         :key="tile.name"
         :name="tile.name"
         :visible="tile.visible"

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -273,63 +273,67 @@ export const stateWideHabitatValues = {
   }
 }
 export const basemaps = [
-  {
-    name: 'ESRI Oceans Basemap',
-    visible: true,
-    url: 'https://server.arcgisonline.com/ArcGIS/rest/services/Ocean_Basemap/MapServer/tile/{z}/{y}/{x}',
-    attribution: 'Tiles &copy; Esri &mdash; Sources: GEBCO, NOAA, CHS, OSU, UNH, CSUMB, National Geographic, DeLorme, NAVTEQ, and Esri'
-  },
-  {
-    name: 'ESRI World Imagery',
-    visible: false,
-    url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
-    attribution: 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community'
-  },
-  {
-    name: 'USGS Imagery',
-    visible: false,
-    url: 'https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryOnly/MapServer/tile/{z}/{y}/{x}',
-    attribution: '<a href="http://www.doi.gov">U.S. Department of the Interior</a> | <a href="http://www.usgs.gov">U.S. Geological Survey</a> | <a href="http://www.usgs.gov/laws/policies_notices.html">Policies</a>',
-    options: {
-      maxZoom: 16
+  [
+    {
+      name: 'ESRI Oceans Basemap',
+      visible: true,
+      url: 'https://server.arcgisonline.com/ArcGIS/rest/services/Ocean_Basemap/MapServer/tile/{z}/{y}/{x}',
+      attribution: 'Tiles &copy; Esri &mdash; Sources: GEBCO, NOAA, CHS, OSU, UNH, CSUMB, National Geographic, DeLorme, NAVTEQ, and Esri'
+    },
+    {
+      name: 'ESRI World Imagery',
+      visible: false,
+      url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+      attribution: 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community'
     }
-  },
-  {
-    name: 'USGS Topo',
-    visible: false,
-    url: 'https://basemap.nationalmap.gov/ArcGIS/rest/services/USGSTopo/MapServer/tile/{z}/{y}/{x}',
-    attribution: '<a href="http://www.doi.gov">U.S. Department of the Interior</a> | <a href="http://www.usgs.gov">U.S. Geological Survey</a> | <a href="http://www.usgs.gov/laws/policies_notices.html">Policies</a>',
-    options: {
-      maxZoom: 16
+  ],
+  [
+    {
+      name: 'USGS Imagery',
+      visible: false,
+      url: 'https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryOnly/MapServer/tile/{z}/{y}/{x}',
+      attribution: '<a href="http://www.doi.gov">U.S. Department of the Interior</a> | <a href="http://www.usgs.gov">U.S. Geological Survey</a> | <a href="http://www.usgs.gov/laws/policies_notices.html">Policies</a>',
+      options: {
+        maxZoom: 16
+      }
+    },
+    {
+      name: 'USGS Topo',
+      visible: false,
+      url: 'https://basemap.nationalmap.gov/ArcGIS/rest/services/USGSTopo/MapServer/tile/{z}/{y}/{x}',
+      attribution: '<a href="http://www.doi.gov">U.S. Department of the Interior</a> | <a href="http://www.usgs.gov">U.S. Geological Survey</a> | <a href="http://www.usgs.gov/laws/policies_notices.html">Policies</a>',
+      options: {
+        maxZoom: 16
+      }
+    },
+    {
+      name: 'USGS Hydrography',
+      visible: false,
+      url: 'https://basemap.nationalmap.gov/arcgis/rest/services/USGSHydroCached/MapServer/tile/{z}/{y}/{x}',
+      attribution: '<a href="http://www.doi.gov">U.S. Department of the Interior</a> | <a href="http://www.usgs.gov">U.S. Geological Survey</a> | <a href="http://www.usgs.gov/laws/policies_notices.html">Policies</a>',
+      options: {
+        maxZoom: 16
+      }
+    },
+    {
+      name: 'OpenStreetMap',
+      visible: false,
+      url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+    },
+    {
+      name: 'No Basemap',
+      visible: false,
+      url: '',
+      attribution: ''
     }
-  },
-  {
-    name: 'USGS Hydrography',
-    visible: false,
-    url: 'https://basemap.nationalmap.gov/arcgis/rest/services/USGSHydroCached/MapServer/tile/{z}/{y}/{x}',
-    attribution: '<a href="http://www.doi.gov">U.S. Department of the Interior</a> | <a href="http://www.usgs.gov">U.S. Geological Survey</a> | <a href="http://www.usgs.gov/laws/policies_notices.html">Policies</a>',
-    options: {
-      maxZoom: 16
-    }
-  },
-  {
-    name: 'OpenStreetMap',
-    visible: false,
-    url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-  },
-  {
-    name: 'No Basemap',
-    visible: false,
-    url: '',
-    attribution: ''
-  }
+  ]
 ]
 export const basemapsWms = [
   {
     url: 'https://gis.charttools.noaa.gov/arcgis/rest/services/MCS/ENCOnline/MapServer/exts/MaritimeChartService/WMSServer',
     name: 'NOAA Nautical Charts',
-    visible: true,
+    visible: false,
     format: 'image/png',
     transparent: true,
     attribution: '<a href="https://nauticalcharts.noaa.gov/data/gis-data-and-services.html" _target="_blank">NOAA Maritime Chart Service</a>'


### PR DESCRIPTION
This is a bit of a hack, but it puts the NOAA nautical maps within the list of basemaps (instead of the top). I just split up the non-WMS basemaps into two chunks and inserted the nautical basemap between them. Note that the `visible` prop on `l-tile-layer` and `l-wms-tile-layer` sets the default (only one should be `true`). 